### PR TITLE
Add handling to check a user's plugSets if collectibleHash is missing (for emotes)

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -22,6 +22,12 @@ interface GuardianInfo {
 
 }
 
+interface DestinyItemPlugBase {
+  plugItemHash: number;
+  canInsert: boolean;
+  enabled: boolean;
+}
+
 enum State {
   Unknown,
   NotRewarded,
@@ -273,13 +279,13 @@ export class AppComponent implements OnInit {
     }
 
     var c = result.Response.profilePlugSets.data.plugs[2860926541]; // emote plugSet
-    var kv = new Map(c.map(plug => [plug.plugItemHash, plug]));
+    var kv = new Map(c.map((plug: DestinyItemPlugBase) => [plug.plugItemHash, plug]));
 
     this.Codes.forEach(code => {
       if (!code.collectibleHash) {  // skip any with collectibleHash as those would not be in plugSets
-        let plug = kv.get(code.itemHash);
-        let existing = plug && plug.canInsert && plug.enable;
-        console.log(code.name, plug?.canInsert, plug?.enable);
+        let plug = kv.get(code.itemHash) as DestinyItemPlugBase;
+        let existing = plug && plug.canInsert && plug.enabled;
+        console.log(code.name, plug?.canInsert, plug?.enabled);
         if (existing)
           code.state = State.Rewarded;
         else

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -199,6 +199,10 @@ export class AppComponent implements OnInit {
   }
 
   async filterCollectibles(membershipType: number, membershipId: number) {
+    if (this.Codes.every(code => !code.collectibleHash)) {
+      // skip the collectibles check if no codes have collectibleHash
+      return;
+    }
     this.loading = true;
     this.errorMessage = "";
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -226,9 +226,7 @@ export class AppComponent implements OnInit {
 
 
     this.Codes.forEach(code => {
-      if (!code.collectibleHash || k.indexOf(code.collectibleHash.toString()) == -1)
-        code.state = State.Unknown;
-      else {
+      if (code.collectibleHash && k.indexOf(code.collectibleHash.toString()) != -1) {
         let existing = (c[code.collectibleHash.toString()].state & 1) == 0;
         console.log(code.name, c[code.collectibleHash.toString()].state, existing)
         if (existing)


### PR DESCRIPTION
This allows for the sole universal-code emote to show up as collected properly instead of always showing up without an acquired/unacquired status.

Based on the docs in https://github.com/Bungie-net/api/wiki/2.2.0-API-Changes, https://bungie-net.github.io/#/components/schemas/Destiny.Sockets.DestinyItemPlugBase, and my own testing with the components=305 query.

Tested across multiple accounts with different states.